### PR TITLE
Make limit works like limit, not like a fill

### DIFF
--- a/lib/exfile_imagemagick/limit.ex
+++ b/lib/exfile_imagemagick/limit.ex
@@ -25,7 +25,7 @@ defmodule ExfileImagemagick.Limit do
     new_path = Exfile.Tempfile.random_file!("imagemagick")
     destination = destination_with_format(new_path, opts)
 
-    dest_dimensions = to_string(width) <> "x" <> to_string(height)
+    dest_dimensions = to_string(width) <> "x" <> to_string(height) <> ">"
     convert_args = [
       file.path,
       "-auto-orient",


### PR DESCRIPTION
I found a difference here: https://github.com/refile/refile-mini_magick/blob/master/lib/refile/mini_magick.rb#L38.

Current limit doesn't work as expected, it resizes to dimensions even if it smaller than `processor_args`.
