### PR TITLE
Elixir 1.4 compilation warnings fix

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,12 +8,12 @@ defmodule ExfileImagemagick.Mixfile do
       elixir: "~> 1.2",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
-      deps: deps,
+      deps: deps(),
       docs: [
         extras: ["README.md"]
       ],
-      package: package,
-      description: description,
+      package: package(),
+      description: description(),
       aliases: [
         "publish": [&git_tag/1, "hex.publish", "hex.docs"]
       ]
@@ -57,9 +57,9 @@ defmodule ExfileImagemagick.Mixfile do
   end
 
   defp git_tag(_args) do
-    version_tag = case Version.parse(project[:version]) do
+    version_tag = case Version.parse(project()[:version]) do
       {:ok, %Version{pre: []}} ->
-        "v" <> project[:version]
+        "v" <> project()[:version]
       _ ->
         raise "Version should be a release version."
     end


### PR DESCRIPTION
@keichan34 please release a new version

```
warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  /home/alex/projects/brutalist/deps/exfile_imagemagick/mix.exs:11

warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
  /home/alex/projects/brutalist/deps/exfile_imagemagick/mix.exs:15

warning: variable "description" does not exist and is being expanded to "description()", please use parentheses to remove the ambiguity or change the variable name
  /home/alex/projects/brutalist/deps/exfile_imagemagick/mix.exs:16

warning: variable "project" does not exist and is being expanded to "project()", please use parentheses to remove the ambiguity or change the variable name
  /home/alex/projects/brutalist/deps/exfile_imagemagick/mix.exs:60

warning: variable "project" does not exist and is being expanded to "project()", please use parentheses to remove the ambiguity or change the variable name
  /home/alex/projects/brutalist/deps/exfile_imagemagick/mix.exs:62
```